### PR TITLE
Fixed bug with null arrays when EmitBehaviors.WhenModified is used.

### DIFF
--- a/src/ExtendedXmlSerializer/ContentModel/Members/AllowedAssignedInstanceValues.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Members/AllowedAssignedInstanceValues.cs
@@ -1,9 +1,9 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using ExtendedXmlSerializer.ContentModel.Reflection;
+﻿using ExtendedXmlSerializer.ContentModel.Reflection;
 using ExtendedXmlSerializer.Core.Specifications;
 using ExtendedXmlSerializer.ReflectionModel;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 
 namespace ExtendedXmlSerializer.ContentModel.Members
 {
@@ -52,7 +52,7 @@ namespace ExtendedXmlSerializer.ContentModel.Members
 		{
 			readonly IEnumerable<T> _other;
 
-			public Specification(IEnumerable<T> other) => _other = other;
+			public Specification(IEnumerable<T> other) => _other = other ?? Enumerable.Empty<T>();
 
 			public bool IsSatisfiedBy(object parameter)
 				=> parameter is IEnumerable<T> other && other.SequenceEqual(_other);

--- a/test/ExtendedXmlSerializer.Tests.ReportedIssues/Issue337Tests.cs
+++ b/test/ExtendedXmlSerializer.Tests.ReportedIssues/Issue337Tests.cs
@@ -1,6 +1,7 @@
 ﻿using ExtendedXmlSerializer.Configuration;
 using ExtendedXmlSerializer.Tests.ReportedIssues.Support;
 using FluentAssertions;
+using JetBrains.Annotations;
 using Xunit;
 
 namespace ExtendedXmlSerializer.Tests.ReportedIssues
@@ -21,6 +22,7 @@ namespace ExtendedXmlSerializer.Tests.ReportedIssues
 
 		class TestClass
 		{
+			[UsedImplicitly]
 			public string[] Array { get; set; }
 		}
 	}

--- a/test/ExtendedXmlSerializer.Tests.ReportedIssues/Issue337Tests.cs
+++ b/test/ExtendedXmlSerializer.Tests.ReportedIssues/Issue337Tests.cs
@@ -1,0 +1,27 @@
+﻿using ExtendedXmlSerializer.Configuration;
+using ExtendedXmlSerializer.Tests.ReportedIssues.Support;
+using FluentAssertions;
+using Xunit;
+
+namespace ExtendedXmlSerializer.Tests.ReportedIssues
+{
+	public sealed class Issue337Tests
+	{
+		[Fact]
+		void Verify()
+		{
+			var instance = new TestClass();
+			new ConfigurationContainer().Emit(EmitBehaviors.WhenModified)
+			                            .Create()
+			                            .ForTesting()
+			                            .Cycle(instance)
+			                            .Should()
+			                            .BeEquivalentTo(instance);
+		}
+
+		class TestClass
+		{
+			public string[] Array { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
Closes #337