### PR TITLE
Member resolution now uses ReflectedType first, then DeclaredType.

### DIFF
--- a/src/ExtendedXmlSerializer/ReflectionModel/MemberComparer.cs
+++ b/src/ExtendedXmlSerializer/ReflectionModel/MemberComparer.cs
@@ -13,7 +13,7 @@ namespace ExtendedXmlSerializer.ReflectionModel
 		public MemberComparer(ITypeComparer type) => _type = type;
 
 		public bool Equals(MemberInfo x, MemberInfo y)
-			=> x.Name.Equals(y.Name) && _type.Equals(x.DeclaringType.GetTypeInfo(), y.DeclaringType.GetTypeInfo());
+			=> x.Name.Equals(y.Name) && _type.Equals(x.ReflectedType.GetTypeInfo(), y.ReflectedType.GetTypeInfo());
 
 		public int GetHashCode(MemberInfo obj) => 0;
 	}

--- a/test/ExtendedXmlSerializer.Tests.ReportedIssues/Issue416Tests.cs
+++ b/test/ExtendedXmlSerializer.Tests.ReportedIssues/Issue416Tests.cs
@@ -1,0 +1,45 @@
+﻿using ExtendedXmlSerializer.Configuration;
+using ExtendedXmlSerializer.Tests.ReportedIssues.Support;
+using FluentAssertions;
+using System.Collections.Generic;
+using Xunit;
+
+namespace ExtendedXmlSerializer.Tests.ReportedIssues
+{
+	public sealed class Issue416Tests
+	{
+		[Fact]
+		public void Verify()
+		{
+			var serializer = new ConfigurationContainer().Type<SubjectA>()
+			                                             .Member(x => x.Signature)
+			                                             .Ignore() // <-- only configuring SubjectA, not SubjectB
+			                                             .Create()
+			                                             .ForTesting();
+
+			var subjects = new List<ISubject>
+			{
+				new SubjectA {Signature = "testa"},
+				new SubjectB {Signature = "testb"}
+			};
+
+			var cycled = serializer.Cycle(subjects);
+			cycled[0].Signature.Should().BeNull();
+			cycled[1].Signature.Should().Be("testb");
+		}
+
+		interface ISubject
+		{
+			string Signature { get; set; }
+		}
+
+		public abstract class BaseSubject : ISubject
+		{
+			public string Signature { get; set; }
+		}
+
+		public class SubjectA : BaseSubject {}
+
+		public class SubjectB : BaseSubject {}
+	}
+}

--- a/test/ExtendedXmlSerializer.Tests.ReportedIssues/Issue416Tests_Extended.cs
+++ b/test/ExtendedXmlSerializer.Tests.ReportedIssues/Issue416Tests_Extended.cs
@@ -70,7 +70,7 @@ namespace ExtendedXmlSerializer.Tests.ReportedIssues
 
 		public class Parent : BaseSubject
 		{
-			public List<ISubject> Commands { get; set; } = new List<ISubject> {};
+			public List<ISubject> Commands { get; set; } = new List<ISubject>();
 		}
 
 		public class SubjectA : BaseSubject {}

--- a/test/ExtendedXmlSerializer.Tests.ReportedIssues/Issue416Tests_Extended.cs
+++ b/test/ExtendedXmlSerializer.Tests.ReportedIssues/Issue416Tests_Extended.cs
@@ -36,7 +36,7 @@ namespace ExtendedXmlSerializer.Tests.ReportedIssues
 			{
 				IgnoreThisEverywhere = "Should NOT see this"
 			};
-			/*var subjectB = new SubjectB {
+			var subjectB = new SubjectB {
 				IgnoreThisForSubset  = "Should see this",
 				IgnoreThisEverywhere = "Should NOT see this"
 			};
@@ -47,10 +47,13 @@ namespace ExtendedXmlSerializer.Tests.ReportedIssues
 					subjectA,
 					subjectB
 				}
-			};*/
+			};
 
-			var cycled = serializer.Cycle(subjectA);
+			var cycled = serializer.Cycle(parent);
 			cycled.IgnoreThisEverywhere.Should().BeNull();
+			cycled.Commands[0].IgnoreThisEverywhere.Should().BeNull();
+			cycled.Commands[1].IgnoreThisEverywhere.Should().BeNull();
+
 		}
 
 		public interface ISubject

--- a/test/ExtendedXmlSerializer.Tests.ReportedIssues/Issue416Tests_Extended.cs
+++ b/test/ExtendedXmlSerializer.Tests.ReportedIssues/Issue416Tests_Extended.cs
@@ -1,0 +1,176 @@
+﻿using ExtendedXmlSerializer.Configuration;
+using ExtendedXmlSerializer.ContentModel.Members;
+using ExtendedXmlSerializer.Core.Specifications;
+using ExtendedXmlSerializer.ExtensionModel;
+using ExtendedXmlSerializer.ExtensionModel.Content.Members;
+using ExtendedXmlSerializer.ExtensionModel.Xml;
+using ExtendedXmlSerializer.ReflectionModel;
+using ExtendedXmlSerializer.Tests.ReportedIssues.Support;
+using FluentAssertions;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace ExtendedXmlSerializer.Tests.ReportedIssues
+{
+	public sealed class Issue416Tests_Extended
+	{
+		[Fact]
+		public void Verify()
+		{
+			var serializer = new ConfigurationContainer(Extensions.Default.ToArray())
+			                 .Type<BaseSubject>()
+			                 .Member(x => x.IgnoreThisEverywhere)
+			                 .Ignore() // <-- This doesn't work
+			                 //.Type<ISubject>().Member(x => x.IgnoreThisEverywhere).Ignore()   // <-- This works
+			                 .Type<SubjectA>()
+			                 .Member(x => x.IgnoreThisForSubset)
+			                 .Ignore()
+			                 .Create()
+			                 .ForTesting();
+
+
+			var subjectA = new SubjectA
+			{
+				IgnoreThisEverywhere = "Should NOT see this"
+			};
+			/*var subjectB = new SubjectB {
+				IgnoreThisForSubset  = "Should see this",
+				IgnoreThisEverywhere = "Should NOT see this"
+			};
+			var parent = new Parent
+			{
+				IgnoreThisForSubset = "Should see this",
+				Commands = new List<ISubject>{
+					subjectA,
+					subjectB
+				}
+			};*/
+
+			var cycled = serializer.Cycle(subjectA);
+			cycled.IgnoreThisEverywhere.Should().BeNull();
+		}
+
+		public interface ISubject
+		{
+			string IgnoreThisForSubset { get; set; }
+			string IgnoreThisEverywhere { get; set; }
+		}
+
+		public abstract class BaseSubject : ISubject
+		{
+			public string IgnoreThisForSubset { get; set; }
+			public string IgnoreThisEverywhere { get; set; }
+		}
+
+		public class Parent : BaseSubject
+		{
+			public List<ISubject> Commands { get; set; } = new List<ISubject> {};
+		}
+
+		public class SubjectA : BaseSubject {}
+
+		public class SubjectB : BaseSubject {}
+
+		sealed class Extensions : IEnumerable<ISerializerExtension>
+		{
+			public static Extensions Default { get; } = new Extensions();
+
+			Extensions() : this(DefaultExtensions.Default) {}
+
+			readonly IEnumerable<ISerializerExtension> _previous;
+
+			public Extensions(IEnumerable<ISerializerExtension> previous) => _previous = previous;
+
+			public IEnumerator<ISerializerExtension> GetEnumerator()
+				=> _previous.Select(extension => extension is IAllowedMembersExtension previous
+					                                 ? new AllowedMembersExtension(previous)
+					                                 : extension)
+				            .GetEnumerator();
+
+			IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+		}
+
+		sealed class AllowedMembersExtension : IAllowedMembersExtension
+		{
+			readonly IAllowedMembersExtension _previous;
+			readonly IMetadataSpecification   _specification;
+
+			public AllowedMembersExtension(IAllowedMembersExtension previous)
+				: this(previous, DefaultMetadataSpecification.Default) {}
+
+			public AllowedMembersExtension(IAllowedMembersExtension previous, IMetadataSpecification specification)
+			{
+				_previous      = previous;
+				_specification = specification;
+			}
+
+			public IServiceRepository Get(IServiceRepository parameter)
+			{
+				var comparer =
+					new MemberComparer(new CompositeTypeComparer(TypeIdentityComparer.Default,
+					                                             AssignableFromTypeComparer.Default));
+
+				var policy = Whitelist.Any()
+					             ? (ISpecification<MemberInfo>)new AllowedPolicy(comparer, Whitelist.ToArray())
+					             : new ProhibitedPolicy(comparer, Blacklist.ToArray());
+
+				return parameter.RegisterInstance(policy.And<PropertyInfo>(_specification))
+				                .RegisterInstance(policy.And<FieldInfo>(_specification));
+			}
+
+			public void Execute(IServices parameter) {}
+
+			public ICollection<MemberInfo> Blacklist => _previous.Blacklist;
+
+			public ICollection<MemberInfo> Whitelist => _previous.Whitelist;
+		}
+
+		sealed class AssignableFromTypeComparer : ITypeComparer
+		{
+			public static AssignableFromTypeComparer Default { get; } = new AssignableFromTypeComparer();
+
+			AssignableFromTypeComparer() {}
+
+			public bool Equals(TypeInfo x, TypeInfo y) => x.IsAssignableFrom(y);
+
+			public int GetHashCode(TypeInfo obj) => 0;
+		}
+
+		sealed class AllowedPolicy : ContainsSpecification<MemberInfo>
+		{
+			public AllowedPolicy(IEqualityComparer<MemberInfo> comparer, params MemberInfo[] avoid)
+				: base(new HashSet<MemberInfo>(avoid, comparer)) {}
+		}
+
+		sealed class ProhibitedPolicy : DecoratedSpecification<MemberInfo>
+		{
+			public ProhibitedPolicy(IEqualityComparer<MemberInfo> comparer, params MemberInfo[] avoid)
+				: this(new HashSet<MemberInfo>(avoid, comparer)) {}
+
+			ProhibitedPolicy(ICollection<MemberInfo> avoid)
+				: base(new ContainsSpecification<MemberInfo>(avoid).Inverse()) {}
+		}
+
+		class ContainsSpecification<T> : DelegatedSpecification<T>
+		{
+			public ContainsSpecification(ICollection<T> source) : base(source.Contains) {}
+
+			public sealed override bool IsSatisfiedBy(T parameter) => base.IsSatisfiedBy(parameter);
+		}
+
+		sealed class MemberComparer : IEqualityComparer<MemberInfo>
+		{
+			readonly ITypeComparer _type;
+
+			public MemberComparer(ITypeComparer type) => _type = type;
+
+			public bool Equals(MemberInfo x, MemberInfo y)
+				=> x.Name.Equals(y.Name) && _type.Equals(x.ReflectedType.GetTypeInfo(), y.ReflectedType.GetTypeInfo());
+
+			public int GetHashCode(MemberInfo obj) => 0;
+		}
+	}
+}

--- a/test/ExtendedXmlSerializer.Tests/ContentModel/Members/BlacklistMemberPolicyTests.cs
+++ b/test/ExtendedXmlSerializer.Tests/ContentModel/Members/BlacklistMemberPolicyTests.cs
@@ -51,6 +51,52 @@ namespace ExtendedXmlSerializer.Tests.ContentModel.Members
 		[Fact]
 		void Overrides()
 		{
+			var member = Get<ButtonBase, bool>(x => x.AutoSize);
+
+			var list = new HashSet<MemberInfo>(MemberComparer.Default) {member};
+
+			list.Contains(typeof(Button).GetTypeInfo()
+			                            .GetRuntimeProperty(nameof(Control.AutoSize)))
+			    .Should()
+			    .BeFalse();
+
+			list.Contains(typeof(ButtonBase).GetTypeInfo()
+			                                .GetRuntimeProperty(nameof(Control.AutoSize)))
+			    .Should()
+			    .BeTrue();
+
+			list.Contains(typeof(Control).GetTypeInfo()
+			                             .GetRuntimeProperty(nameof(Control.AutoSize)))
+			    .Should()
+			    .BeFalse();
+		}
+
+		[Fact]
+		void Overrides_Inherited()
+		{
+			var member = Get<ButtonBase, bool>(x => x.AutoSize);
+
+			var list = new HashSet<MemberInfo>(InheritedMemberComparer.Default.Get()) {member};
+
+			list.Contains(typeof(Button).GetTypeInfo()
+			                            .GetRuntimeProperty(nameof(Control.AutoSize)))
+			    .Should()
+			    .BeTrue();
+
+			list.Contains(typeof(ButtonBase).GetTypeInfo()
+			                                .GetRuntimeProperty(nameof(Control.AutoSize)))
+			    .Should()
+			    .BeTrue();
+
+			list.Contains(typeof(Control).GetTypeInfo()
+			                             .GetRuntimeProperty(nameof(Control.AutoSize)))
+			    .Should()
+			    .BeFalse();
+		}
+
+		[Fact]
+		void Overrides_Implemented()
+		{
 			var member = Get<Button, bool>(x => x.AutoSize);
 
 			var list = new HashSet<MemberInfo>(MemberComparer.Default) {member};
@@ -63,7 +109,30 @@ namespace ExtendedXmlSerializer.Tests.ContentModel.Members
 			list.Contains(typeof(ButtonBase).GetTypeInfo()
 			                                .GetRuntimeProperty(nameof(Control.AutoSize)))
 			    .Should()
+			    .BeFalse();
+
+			list.Contains(typeof(Control).GetTypeInfo()
+			                             .GetRuntimeProperty(nameof(Control.AutoSize)))
+			    .Should()
+			    .BeFalse();
+		}
+
+		[Fact]
+		void Overrides_Implemented_Inherited()
+		{
+			var member = Get<Button, bool>(x => x.AutoSize);
+
+			var list = new HashSet<MemberInfo>(InheritedMemberComparer.Default.Get()) {member};
+
+			list.Contains(typeof(Button).GetTypeInfo()
+			                            .GetRuntimeProperty(nameof(Control.AutoSize)))
+			    .Should()
 			    .BeTrue();
+
+			list.Contains(typeof(ButtonBase).GetTypeInfo()
+			                                .GetRuntimeProperty(nameof(Control.AutoSize)))
+			    .Should()
+			    .BeFalse();
 
 			list.Contains(typeof(Control).GetTypeInfo()
 			                             .GetRuntimeProperty(nameof(Control.AutoSize)))


### PR DESCRIPTION
…type.