### PR TITLE
Allowed `null` Namespace for Framework Types

### DIFF
--- a/src/ExtendedXmlSerializer/ContentModel/Reflection/PartitionedTypeSpecification.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Reflection/PartitionedTypeSpecification.cs
@@ -25,6 +25,6 @@ namespace ExtendedXmlSerializer.ContentModel.Reflection
 		public NotHappy(Assembly assembly) => _assembly = assembly;
 
 		public bool IsSatisfiedBy(TypeInfo parameter)
-			=> parameter.Assembly != _assembly || !parameter.Namespace.Contains("System.Runtime.Remoting");
+			=> parameter?.Assembly != _assembly;
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Reflection/PartitionedTypeSpecification.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Reflection/PartitionedTypeSpecification.cs
@@ -1,32 +1,20 @@
-using ExtendedXmlSerializer.Core.Specifications;
 using System.Reflection;
 
 namespace ExtendedXmlSerializer.ContentModel.Reflection
 {
-	sealed class PartitionedTypeSpecification
-		: DecoratedSpecification<TypeInfo>,
-		  IPartitionedTypeSpecification
+	sealed class PartitionedTypeSpecification : IPartitionedTypeSpecification
 	{
 		public static PartitionedTypeSpecification Default { get; } = new PartitionedTypeSpecification();
 
-		PartitionedTypeSpecification() : base(NotHappy.Default) {}
-	}
-
-	sealed class NotHappy : ISpecification<TypeInfo>
-		// HACK: This is a bit of a hack -- ok a total hack, to pass a test for .NET Framework under special conditions: https://github.com/ExtendedXmlSerializer/home/issues/248
-		// This doesn't occur for .NET Core, but we will have to do better for v3 in any case.
-	{
-		public static NotHappy Default { get; } = new NotHappy();
-
-		NotHappy() : this(typeof(object).Assembly) {}
+		PartitionedTypeSpecification() : this(typeof(object).Assembly) {}
 
 		readonly Assembly _assembly;
 
-		public NotHappy(Assembly assembly) => _assembly = assembly;
+		public PartitionedTypeSpecification(Assembly assembly) => _assembly = assembly;
 
+		// HACK: This is a bit of a hack -- ok a total hack, to pass a test for .NET Framework under special conditions:
+		// https://github.com/ExtendedXmlSerializer/home/issues/248
 		public bool IsSatisfiedBy(TypeInfo parameter)
-			=> parameter.Assembly != _assembly
-			   ||
-			   (!parameter.Namespace?.Contains("System.Runtime.Remoting") ?? false);
+			=> parameter.Assembly != _assembly || (!parameter.Namespace?.Contains("System.Runtime.Remoting") ?? true);
 	}
 }

--- a/src/ExtendedXmlSerializer/ContentModel/Reflection/PartitionedTypeSpecification.cs
+++ b/src/ExtendedXmlSerializer/ContentModel/Reflection/PartitionedTypeSpecification.cs
@@ -25,6 +25,8 @@ namespace ExtendedXmlSerializer.ContentModel.Reflection
 		public NotHappy(Assembly assembly) => _assembly = assembly;
 
 		public bool IsSatisfiedBy(TypeInfo parameter)
-			=> parameter?.Assembly != _assembly;
+			=> parameter.Assembly != _assembly
+			   ||
+			   (!parameter.Namespace?.Contains("System.Runtime.Remoting") ?? false);
 	}
 }


### PR DESCRIPTION
This is a fix for a critical issue we recently experienced with a .NET Core app running in a production environment where deserilization calls started returning exceptions at seemingly random intervals.

The issue began occurring without any changes to how the serializer is handled or the structure of the objects being serialized. We were not able to reproduce this issue outside of production.

Below is an example of the exceptions we were seeing:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at ExtendedXmlSerializer.ContentModel.Reflection.NotHappy.IsSatisfiedBy(TypeInfo parameter)
   at System.Linq.Enumerable.WhereArrayIterator`1.MoveNext()
   at System.Linq.Lookup`2.Create(IEnumerable`1 source, Func`2 keySelector, IEqualityComparer`1 comparer)
   at ExtendedXmlSerializer.ContentModel.Reflection.IdentityPartitionedTypeCandidates.TypeNamePartition.Get(KeyValuePair`2 parameter)
   at System.Linq.Enumerable.ToDictionary[TSource,TKey,TElement](IEnumerable`1 source, Func`2 keySelector, Func`2 elementSelector, IEqualityComparer`1 comparer)
   at ExtendedXmlSerializer.ContentModel.Reflection.IdentityPartitionedTypeCandidates..ctor(ISpecification`1 specification, ITypeFormatter formatter)
   at ExtendedXmlSerializer.ContentModel.Reflection.Types..ctor(IPartitionedTypeSpecification specification, IAssemblyTypePartitions partitions, ITypeIdentities identities, ITypeFormatter formatter)
   at DynamicMethod(Object[] , Scope )
   at LightInject.PerContainerLifetime.GetInstance(Func`1 createInstance, Scope scope)
   at LightInject.ServiceContainer.EmitLifetime(ServiceRegistration serviceRegistration, Action`1 emitMethod, IEmitter emitter)
   at LightInject.ServiceContainer.<>c__DisplayClass162_0.<CreateEmitMethodWrapper>b__0(IEmitter ms)
   at LightInject.ServiceContainer.EmitConstructorDependency(IEmitter emitter, Dependency dependency)
   at LightInject.ServiceContainer.EmitConstructorDependencies(ConstructionInfo constructionInfo, IEmitter emitter, Action`1 decoratorTargetEmitter)
   at LightInject.ServiceContainer.EmitNewInstanceUsingImplementingType(IEmitter emitter, ConstructionInfo constructionInfo, Action`1 decoratorTargetEmitMethod)
   at LightInject.ServiceContainer.EmitNewInstance(ServiceRegistration serviceRegistration, IEmitter emitter)
   at LightInject.ServiceContainer.CreateDynamicMethodDelegate(Action`1 serviceEmitter)
   at LightInject.ServiceContainer.<>c__DisplayClass205_0.<EmitLifetime>b__1()
   at LightInject.PerContainerLifetime.GetInstance(Func`1 createInstance, Scope scope)
   at LightInject.ServiceContainer.EmitLifetime(ServiceRegistration serviceRegistration, Action`1 emitMethod, IEmitter emitter)
   at LightInject.ServiceContainer.<>c__DisplayClass162_0.<CreateEmitMethodWrapper>b__0(IEmitter ms)
   at LightInject.ServiceContainer.EmitConstructorDependency(IEmitter emitter, Dependency dependency)
   at LightInject.ServiceContainer.EmitConstructorDependencies(ConstructionInfo constructionInfo, IEmitter emitter, Action`1 decoratorTargetEmitter)
   at LightInject.ServiceContainer.EmitNewInstanceUsingImplementingType(IEmitter emitter, ConstructionInfo constructionInfo, Action`1 decoratorTargetEmitMethod)
   at LightInject.ServiceContainer.EmitNewInstance(ServiceRegistration serviceRegistration, IEmitter emitter)
   at LightInject.ServiceContainer.CreateDynamicMethodDelegate(Action`1 serviceEmitter)
   at LightInject.ServiceContainer.<>c__DisplayClass205_0.<EmitLifetime>b__1()
   at LightInject.PerContainerLifetime.GetInstance(Func`1 createInstance, Scope scope)
   at LightInject.ServiceContainer.EmitLifetime(ServiceRegistration serviceRegistration, Action`1 emitMethod, IEmitter emitter)
   at LightInject.ServiceContainer.<>c__DisplayClass162_0.<CreateEmitMethodWrapper>b__0(IEmitter ms)
   at LightInject.ServiceContainer.EmitConstructorDependency(IEmitter emitter, Dependency dependency)
   at LightInject.ServiceContainer.EmitConstructorDependencies(ConstructionInfo constructionInfo, IEmitter emitter, Action`1 decoratorTargetEmitter)
   at LightInject.ServiceContainer.EmitNewInstanceUsingImplementingType(IEmitter emitter, ConstructionInfo constructionInfo, Action`1 decoratorTargetEmitMethod)
   at LightInject.ServiceContainer.EmitNewInstance(ServiceRegistration serviceRegistration, IEmitter emitter)
   at LightInject.ServiceContainer.CreateDynamicMethodDelegate(Action`1 serviceEmitter)
   at LightInject.ServiceContainer.<>c__DisplayClass205_0.<EmitLifetime>b__1()
   at LightInject.PerContainerLifetime.GetInstance(Func`1 createInstance, Scope scope)
   at LightInject.ServiceContainer.EmitLifetime(ServiceRegistration serviceRegistration, Action`1 emitMethod, IEmitter emitter)
   at LightInject.ServiceContainer.<>c__DisplayClass162_0.<CreateEmitMethodWrapper>b__0(IEmitter ms)
   at LightInject.ServiceContainer.EmitConstructorDependency(IEmitter emitter, Dependency dependency)
   at LightInject.ServiceContainer.EmitConstructorDependencies(ConstructionInfo constructionInfo, IEmitter emitter, Action`1 decoratorTargetEmitter)
   at LightInject.ServiceContainer.EmitNewInstanceUsingImplementingType(IEmitter emitter, ConstructionInfo constructionInfo, Action`1 decoratorTargetEmitMethod)
   at LightInject.ServiceContainer.EmitNewInstance(ServiceRegistration serviceRegistration, IEmitter emitter)
   at LightInject.ServiceContainer.CreateDynamicMethodDelegate(Action`1 serviceEmitter)
   at LightInject.ServiceContainer.<>c__DisplayClass205_0.<EmitLifetime>b__1()
   at LightInject.PerContainerLifetime.GetInstance(Func`1 createInstance, Scope scope)
   at LightInject.ServiceContainer.EmitLifetime(ServiceRegistration serviceRegistration, Action`1 emitMethod, IEmitter emitter)
   at LightInject.ServiceContainer.<>c__DisplayClass162_0.<CreateEmitMethodWrapper>b__0(IEmitter ms)
   at LightInject.ServiceContainer.EmitConstructorDependency(IEmitter emitter, Dependency dependency)
   at LightInject.ServiceContainer.EmitConstructorDependencies(ConstructionInfo constructionInfo, IEmitter emitter, Action`1 decoratorTargetEmitter)
   at LightInject.ServiceContainer.EmitNewInstanceUsingImplementingType(IEmitter emitter, ConstructionInfo constructionInfo, Action`1 decoratorTargetEmitMethod)
   at LightInject.ServiceContainer.EmitNewInstance(ServiceRegistration serviceRegistration, IEmitter emitter)
   at LightInject.ServiceContainer.CreateDynamicMethodDelegate(Action`1 serviceEmitter)
   at LightInject.ServiceContainer.<>c__DisplayClass205_0.<EmitLifetime>b__1()
   at LightInject.PerContainerLifetime.GetInstance(Func`1 createInstance, Scope scope)
   at LightInject.ServiceContainer.EmitLifetime(ServiceRegistration serviceRegistration, Action`1 emitMethod, IEmitter emitter)
   at LightInject.ServiceContainer.<>c__DisplayClass162_0.<CreateEmitMethodWrapper>b__0(IEmitter ms)
   at LightInject.ServiceContainer.CreateDynamicMethodDelegate(Action`1 serviceEmitter)
   at LightInject.ServiceContainer.CreateDelegate(Type serviceType, String serviceName, Boolean throwError)
   at LightInject.ServiceContainer.CreateDefaultDelegate(Type serviceType, Boolean throwError)
   at LightInject.ServiceContainer.GetInstance(Type serviceType)
   at ExtendedXmlSerializer.Core.Extensions.Get[T](IServiceProvider this)
   at ExtendedXmlSerializer.Configuration.RootContext.Create()
```