### PR TITLE
Added non-generic versions of `EnableImplicitTypingFrom*` methods

### DIFF
--- a/src/ExtendedXmlSerializer/ExtensionMethodsForImplicitTyping.cs
+++ b/src/ExtendedXmlSerializer/ExtensionMethodsForImplicitTyping.cs
@@ -93,6 +93,19 @@ namespace ExtendedXmlSerializer
 			=> @this.EnableImplicitTyping(new PublicAssemblyTypes<T>());
 
 		/// <summary>
+		/// Convenience method to enable implicit typing on a container, using all found public types within the provided
+		/// subject type's assembly.  All public types found within the provided subject type's assembly will be included and
+		/// registered as an implicit type.  Use this with care and ensure that the names of all the public types found within
+		/// the assembly are unique.  Otherwise, an exception will be thrown if more than one type share the same name.
+		/// </summary>
+		/// <param name="this">The configuration container to configure.</param>
+		/// <param name="type">The subject type to query for type resolution.</param>
+		/// <returns>The configured configuration container.</returns>
+		/// <seealso cref="EnableImplicitTyping(IConfigurationContainer,System.Type[])"/>
+		public static IConfigurationContainer EnableImplicitTypingFromPublic(this IConfigurationContainer @this, Type type)
+			=> @this.EnableImplicitTyping(new PublicAssemblyTypes(type));
+
+		/// <summary>
 		/// Convenience method to enable implicit typing on a container, using all found types within the provided subject
 		/// type's namespace.  All types found within the provided subject type's namespace will be included and registered as
 		/// an implicit type.  Use this with care and ensure that the names of all the types found within the namespace are

--- a/src/ExtendedXmlSerializer/ExtensionMethodsForImplicitTyping.cs
+++ b/src/ExtendedXmlSerializer/ExtensionMethodsForImplicitTyping.cs
@@ -55,6 +55,19 @@ namespace ExtendedXmlSerializer
 			=> @this.EnableImplicitTyping(new PublicNestedTypes<T>());
 
 		/// <summary>
+		/// Convenience method to enable implicit typing on a container, using all public-nested types found within the
+		/// provided subject type.  All public nested types found within the provided subject type will be included as an
+		/// implicit type.
+		/// </summary>
+		/// <param name="this">The configuration container to configure.</param>
+		/// <param name="type">The subject type to query for type resolution.</param>
+		/// <returns>The configured configuration container.</returns>
+		/// <seealso cref="EnableImplicitTyping(IConfigurationContainer,System.Type[])"/>
+		public static IConfigurationContainer EnableImplicitTypingFromPublicNested(
+			this IConfigurationContainer @this, Type type)
+			=> @this.EnableImplicitTyping(new PublicNestedTypes(type));
+
+		/// <summary>
 		/// Convenience method to enable implicit typing on a container, using all nested types -- private or otherwise --
 		/// found within the provided subject type.  All nested types found within the provided subject type will be
 		/// included and registered as an implicit type.
@@ -65,6 +78,19 @@ namespace ExtendedXmlSerializer
 		/// <seealso cref="EnableImplicitTyping(IConfigurationContainer,System.Type[])"/>
 		public static IConfigurationContainer EnableImplicitTypingFromNested<T>(this IConfigurationContainer @this)
 			=> @this.EnableImplicitTyping(new NestedTypes<T>());
+
+		/// <summary>
+		/// Convenience method to enable implicit typing on a container, using all nested types -- private or otherwise --
+		/// found within the provided subject type.  All nested types found within the provided subject type will be
+		/// included and registered as an implicit type.
+		/// </summary>
+		/// <param name="this">The configuration container to configure.</param>
+		/// <param name="type">The subject type to query for type resolution.</param>
+		/// <returns>The configured configuration container.</returns>
+		/// <seealso cref="EnableImplicitTyping(IConfigurationContainer,System.Type[])"/>
+		public static IConfigurationContainer EnableImplicitTypingFromNested(this IConfigurationContainer @this, Type type)
+			=> @this.EnableImplicitTyping(new NestedTypes(type));
+
 
 		/// <summary>
 		/// Convenience method to enable implicit typing on a container, using all found types within the provided subject
@@ -78,6 +104,19 @@ namespace ExtendedXmlSerializer
 		/// <seealso cref="EnableImplicitTyping(IConfigurationContainer,System.Type[])"/>
 		public static IConfigurationContainer EnableImplicitTypingFromAll<T>(this IConfigurationContainer @this)
 			=> @this.EnableImplicitTyping(new AllAssemblyTypes<T>());
+
+		/// <summary>
+		/// Convenience method to enable implicit typing on a container, using all found types within the provided subject
+		/// type's assembly.  All types found within the provided subject type's assembly will be included and registered as
+		/// an implicit type.  Use this with care and ensure that the names of all the types found within the assembly are
+		/// unique. Otherwise, an exception will be thrown if more than one type share the same name.
+		/// </summary>
+		/// <param name="this">The configuration container to configure.</param>
+		/// <param name="type">The subject type to query for type resolution.</param>
+		/// <returns>The configured configuration container.</returns>
+		/// <seealso cref="EnableImplicitTyping(IConfigurationContainer,System.Type[])"/>
+		public static IConfigurationContainer EnableImplicitTypingFromAll(this IConfigurationContainer @this, Type type)
+			=> @this.EnableImplicitTyping(new AllAssemblyTypes(type));
 
 		/// <summary>
 		/// Convenience method to enable implicit typing on a container, using all found public types within the provided
@@ -119,6 +158,19 @@ namespace ExtendedXmlSerializer
 			=> @this.EnableImplicitTyping(new AllTypesInSameNamespace<T>());
 
 		/// <summary>
+		/// Convenience method to enable implicit typing on a container, using all found types within the provided subject
+		/// type's namespace.  All types found within the provided subject type's namespace will be included and registered as
+		/// an implicit type.  Use this with care and ensure that the names of all the types found within the namespace are
+		/// unique. Otherwise, an exception will be thrown if more than one type share the same name.
+		/// </summary>
+		/// <param name="this">The configuration container to configure.</param>
+		/// <param name="type">The subject type to query for type resolution.</param>
+		/// <returns>The configured configuration container.</returns>
+		/// <seealso cref="EnableImplicitTyping(IConfigurationContainer,System.Type[])"/>
+		public static IConfigurationContainer EnableImplicitTypingFromNamespace(this IConfigurationContainer @this, Type type)
+			=> @this.EnableImplicitTyping(new AllTypesInSameNamespace(type));
+
+		/// <summary>
 		/// Convenience method to enable implicit typing on a container, using all found public types within the provided
 		/// subject type's namespace.  All public types found within the provided subject type's namespace will be included and
 		/// registered as an implicit type.  Use this with care and ensure that the names of all the public types found within
@@ -131,5 +183,19 @@ namespace ExtendedXmlSerializer
 		public static IConfigurationContainer EnableImplicitTypingFromNamespacePublic<T>(
 			this IConfigurationContainer @this)
 			=> @this.EnableImplicitTyping(new PublicTypesInSameNamespace<T>());
+
+		/// <summary>
+		/// Convenience method to enable implicit typing on a container, using all found public types within the provided
+		/// subject type's namespace.  All public types found within the provided subject type's namespace will be included and
+		/// registered as an implicit type.  Use this with care and ensure that the names of all the public types found within
+		/// the namespace are unique.  Otherwise, an exception will be thrown if more than one type share the same name.
+		/// </summary>
+		/// <param name="this">The configuration container to configure.</param>
+		/// <param name="type">The subject type to query for type resolution.</param>
+		/// <returns>The configured configuration container.</returns>
+		/// <seealso cref="EnableImplicitTyping(IConfigurationContainer,System.Type[])"/>
+		public static IConfigurationContainer EnableImplicitTypingFromNamespacePublic(
+			this IConfigurationContainer @this, Type type)
+			=> @this.EnableImplicitTyping(new PublicTypesInSameNamespace(type));
 	}
 }


### PR DESCRIPTION
Current implementation of `EnableImplicitTypingFromPublic` allows to pass type as a generic parameter only. I have created non-generic variant that takes `Type` as ordinary parameter instead of generic.