### PR TITLE
Fixed an issue where strings would be handled as collection of chars

### DIFF
--- a/src/ExtendedXmlSerializer/ExtensionModel/Xml/XmlTextExtension.cs
+++ b/src/ExtendedXmlSerializer/ExtensionModel/Xml/XmlTextExtension.cs
@@ -153,7 +153,9 @@ namespace ExtendedXmlSerializer.ExtensionModel.Xml
 
 			IMemberSerializer Create(IMemberSerializer serializer, Type owner)
 			{
-				var item = CollectionItemTypeLocator.Default.Get(serializer.Profile.MemberType);
+				var item = serializer.Profile.MemberType == typeof(string)
+                    ? null  // strings should not be serialized as a collection of char
+                    : CollectionItemTypeLocator.Default.Get(serializer.Profile.MemberType);
 				var itemType = _member.Get(owner)
 				                      .Item1;
 				var member = (IMemberSerializer)new MemberSerializer(serializer, _converters.Get(itemType));

--- a/test/ExtendedXmlSerializer.Tests.ReportedIssues/Issue192Tests.cs
+++ b/test/ExtendedXmlSerializer.Tests.ReportedIssues/Issue192Tests.cs
@@ -29,7 +29,11 @@ namespace ExtendedXmlSerializer.Tests.ReportedIssues
 			serializer.Cycle(second)
 			          .Should().BeEquivalentTo(second);
 
-			var group = new Group2 {Type = GroupType.Large};
+            var third = new SubjectWithMembers2 { Item = 123, Message = "Message", Time = DateTimeOffset.Now };
+            serializer.Cycle(third)
+                      .Should().BeEquivalentTo(third);
+
+            var group = new Group2 {Type = GroupType.Large};
 			serializer.Cycle(group)
 			          .Should().BeEquivalentTo(group);
 
@@ -78,7 +82,17 @@ namespace ExtendedXmlSerializer.Tests.ReportedIssues
 			public DateTimeOffset Time { [UsedImplicitly] get; set; }
 		}
 
-		public class Group2
+        public class SubjectWithMembers2
+        {
+            [XmlText]
+            public string Message { [UsedImplicitly] get; set; }
+
+            public int Item { get; set; }
+
+            public DateTimeOffset Time { [UsedImplicitly] get; set; }
+        }
+
+        public class Group2
 		{
 			[XmlText(Type = typeof(GroupType))] public GroupType Type = GroupType.Small;
 		}


### PR DESCRIPTION
When a property of type string is decorated with XmlTextAttribute and when the serializer is configured with EnableXmlText(), then the deserialization would throw a NullReferenceException. The reason is that a ListSerializer is created for string types instead of the MemberSerializer.

This is closely related to issue #192.